### PR TITLE
[Challenge 2] Implement 'conch' API

### DIFF
--- a/lib/collections.c
+++ b/lib/collections.c
@@ -9,6 +9,7 @@ typedef struct Node
     struct Node* next;
 } Node;
 
+// Queue ADT
 typedef struct Queue
 {
     Node* head;
@@ -87,3 +88,33 @@ void queue_free(Queue* queue)
     }
     free(queue);
 }
+
+// Conch ADT
+typedef struct Conch
+{
+    int64_t conch_value;
+    bool conch_available;
+} Conch;
+
+Conch* conch_init(int64_t initial_conch_value)
+{
+    Conch* conch = malloc(sizeof(Conch));
+    conch->conch_value = initial_conch_value;
+    return conch;
+}
+
+void conch_checkin(Conch* conch, int64_t new_conch_value)
+{
+    conch->conch_value = new_conch_value;
+    conch->conch_available = true;
+}
+
+int64_t conch_checkout(Conch* conch)
+{
+    conch->conch_available = false;
+    return conch->conch_value;
+}
+
+bool conch_is_available(Conch* conch) { return conch->conch_available; }
+
+void conch_free(Conch* conch) { free(conch); }

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -100,6 +100,7 @@ Conch* conch_init(int64_t initial_conch_value)
 {
     Conch* conch = malloc(sizeof(Conch));
     conch->conch_value = initial_conch_value;
+    conch->conch_available = false;
     return conch;
 }
 
@@ -111,6 +112,11 @@ void conch_checkin(Conch* conch, int64_t new_conch_value)
 
 int64_t conch_checkout(Conch* conch)
 {
+    if (!conch_is_available(conch))
+    {
+        fprintf(stderr, "Error: conch_checkout: conch is not available\n");
+        exit(EXIT_FAILURE);
+    }
     conch->conch_available = false;
     return conch->conch_value;
 }

--- a/lib/collections.h
+++ b/lib/collections.h
@@ -2,8 +2,10 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 typedef struct Queue Queue;
+typedef struct Conch Conch;
 
 Queue* queue_init(size_t size);
 void queue_enqueue(Queue* queue, void* data);
@@ -11,3 +13,9 @@ void* queue_dequeue(Queue* queue);
 bool queue_is_full(Queue* queue);
 bool queue_is_empty(Queue* queue);
 void queue_free(Queue* queue);
+
+Conch* conch_init(int64_t initial_conch_value);
+void conch_checkin(Conch* conch, int64_t new_conch_value);
+int64_t conch_checkout(Conch* conch);
+bool conch_is_available(Conch* conch);
+void conch_free(Conch* conch);

--- a/notes/2023-07-25.md
+++ b/notes/2023-07-25.md
@@ -1,0 +1,68 @@
+# Dev Notes
+
+2023-07-25
+
+## Accomplishments 🏆
+
+- Design message schemas; settle on "event-driven control flow" approach
+- Implement `client_response_handler`, `conch_response_handler`
+
+## Recap ⏪
+
+### Conch Request
+
+```json
+{
+  "src": "n_",
+  /* dest is always n0 */
+  "dest": "n0",
+  "body": { "type": "conch_request", "original_client_request": _ }
+}
+```
+
+### Conch Response
+
+```json
+{
+  // src is always n0
+  "src": "n0",
+  "dest": "n_",
+  "body": { "type": "conch_response", "conch_value": _, client_id": "c_" }
+}
+```
+
+### Conch Release
+
+```json
+{
+  "src": "n_",
+  /* dest is always n0 */
+  "dest": "n0",
+  "body": { "type": "conch_release", "conch_value": _ }
+}
+```
+
+### Follower Node
+
+| Status | Incoming       | Outgoing                                                   |
+| ------ | -------------- | ---------------------------------------------------------- |
+| ✅     | client request | `client_response_handler` (conch request)                  |
+| ✅     | conch response | `conch_response_handler` (client response + conch release) |
+
+### Leader Node
+
+| Status | Incoming       | Outgoing                                                   |
+| ------ | -------------- | ---------------------------------------------------------- |
+| ✅     | client request | `client_response_handler` (conch request)                  |
+| ✅     | conch response | `conch_response_handler` (client response + conch release) |
+| 🔲     | conch request  | enqueue                                                    |
+| 🔲     | conch release  | "update conch holder"                                      |
+| 🔲     | "dequeue"[^1]  | "updated conch holder", conch response                     |
+
+## TODOs 📝
+
+- []
+
+---
+
+[^1]: Only if conch is available

--- a/notes/2023-07-25.md
+++ b/notes/2023-07-25.md
@@ -14,9 +14,8 @@
 ```json
 {
   "src": "n_",
-  /* dest is always n0 */
   "dest": "n0",
-  "body": { "type": "conch_request", "original_client_request": _ }
+  "body": { "type": "conch_request", "original_client_request": "_" }
 }
 ```
 
@@ -24,10 +23,13 @@
 
 ```json
 {
-  // src is always n0
   "src": "n0",
   "dest": "n_",
-  "body": { "type": "conch_response", "conch_value": _, client_id": "c_" }
+  "body": {
+    "type": "conch_response",
+    "conch_value": "_",
+    "original_client_request": "_"
+  }
 }
 ```
 
@@ -36,9 +38,8 @@
 ```json
 {
   "src": "n_",
-  /* dest is always n0 */
   "dest": "n0",
-  "body": { "type": "conch_release", "conch_value": _ }
+  "body": { "type": "conch_release", "conch_value": "_" }
 }
 ```
 
@@ -46,22 +47,23 @@
 
 | Status | Incoming       | Outgoing                                                   |
 | ------ | -------------- | ---------------------------------------------------------- |
-| ✅     | client request | `client_response_handler` (conch request)                  |
+| ✅     | client request | `client_request_handler` (conch request)                   |
 | ✅     | conch response | `conch_response_handler` (client response + conch release) |
 
 ### Leader Node
 
-| Status | Incoming       | Outgoing                                                   |
-| ------ | -------------- | ---------------------------------------------------------- |
-| ✅     | client request | `client_response_handler` (conch request)                  |
-| ✅     | conch response | `conch_response_handler` (client response + conch release) |
-| 🔲     | conch request  | enqueue                                                    |
-| 🔲     | conch release  | "update conch holder"                                      |
-| 🔲     | "dequeue"[^1]  | "updated conch holder", conch response                     |
+| Status | Incoming          | Outgoing                                                    |
+| ------ | ----------------- | ----------------------------------------------------------- |
+| ✅     | client request    | `client_request_handler` (conch request)                    |
+| ✅     | conch response    | `conch_response_handler` (client response + conch release)  |
+| ✅     | conch request     | `conch_request_handler` (enqueue)                           |
+| ✅     | conch release     | `conch_release_handler` (update conch)                      |
+| ✅     | N/A (dequeue[^1]) | `conch_response_dispatcher` (update conch + conch response) |
 
 ## TODOs 📝
 
-- []
+- [x] **Ravi**: Finish implementing Leader node functions
+- [ ] **Kevan**: Implement event loops
 
 ---
 

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -47,6 +47,9 @@ void conch_request_handler(json_object* conch_request, Queue* request_queue)
         json_object_object_get(body, "original_client_request");
     queue_enqueue(request_queue, original_client_request);
     json_object_get(original_client_request);
+
+    // Clean up: Free conch request message
+    json_object_put(conch_request);
 }
 
 // Used exclusively by Leader
@@ -96,6 +99,9 @@ void conch_release_handler(json_object* conch_release, Conch* conch)
     int64_t new_conch_value =
         json_object_get_int64(json_object_object_get(body, "conch_value"));
     conch_checkin(conch, new_conch_value);
+
+    // Clean up: free conch release message
+    json_object_put(conch_release);
 }
 
 void client_request_handler(json_object* client_request)
@@ -119,6 +125,9 @@ void client_request_handler(json_object* client_request)
 
     // Send conch request message (to Leader)
     msg_send(conch_request);
+
+    // Clean up: free client request message
+    json_object_put(client_request);
 }
 
 void conch_response_handler(json_object* conch_response)
@@ -160,4 +169,7 @@ void conch_response_handler(json_object* conch_response)
 
     // Send conch release message (to Leader)
     msg_send(conch_release);
+
+    // Clean up: free conch response message
+    json_object_put(conch_response);
 }

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -3,42 +3,110 @@
 
 #include "../../lib/collections.h"
 #include "../../lib/util.h"
+#include "json-c/json_object.h"
 
 json_object* init_reply(json_object* init_msg);
 
+void client_request_handler(json_object* client_request);
+void conch_response_handler(json_object* conch_response);
+
+char* LEADER_NODE = "n0";
+
+void client_request_handler(json_object* client_request)
+{
+
+    /* Conch request schema
+    {
+      "src": "n_",
+      "dest": "n0",
+      "body": { "type": "conch_request", "client_id": "c_" }
+    }
+    */
+    json_object* conch_request = json_object_new_object();
+
+    json_object* dest = json_object_new_string(LEADER_NODE);
+    json_object_object_add(conch_request, "dest", dest);
+
+    json_object* src = json_object_object_get(client_request, "dest");
+    json_object_get(src);
+    json_object_object_add(conch_request, "src", src);
+
+    json_object* body = json_object_new_object();
+    json_object_object_add(body, "type",
+                           json_object_new_string("conch_request"));
+    json_object_get(client_request);
+    json_object_object_add(body, "original_client_request", client_request);
+    json_object_object_add(conch_request, "body", body);
+
+    msg_send(conch_request);
+}
+
+void conch_response_handler(json_object* conch_response)
+{
+    /* Conch response schema
+    {
+      "src": "n0",
+      "dest": "n_",
+      "body": { "msg_id": _, "type": "conch_response", "conch_value": _,
+    "original_client_request": _ }
+    }
+    */
+
+    json_object* conch_response_body =
+        json_object_object_get(conch_response, "body");
+    json_object* client_response = generic_reply(
+        json_object_object_get(conch_response_body, "original_client_request"));
+
+    // id set to current conch_value
+    json_object* conch_value =
+        json_object_object_get(conch_response_body, "conch_value");
+    json_object_get(conch_value);
+    json_object_object_add(json_object_object_get(client_response, "body"),
+                           "conch value", conch_value);
+
+    // Send response message to client
+    msg_send(client_response);
+
+    // Increment conch_value
+    int64_t new_conch_value = json_object_get_int64(conch_value) + 1;
+
+    /* Conch release schema
+    {
+      "src": "n_",
+      "dest": "n0",
+      "body": { "type": "conch_release", "conch_value": _ }
+    }
+    */
+    json_object* conch_release = json_object_new_object();
+
+    json_object* dest = json_object_new_string(LEADER_NODE);
+    json_object_object_add(conch_release, "dest", dest);
+
+    json_object* src = json_object_object_get(conch_response, "dest");
+    json_object_get(src);
+    json_object_object_add(conch_release, "src", src);
+
+    json_object* conch_release_body = json_object_new_object();
+    json_object_object_add(conch_release_body, "type",
+                           json_object_new_string("conch_rerelease"));
+    json_object_object_add(conch_release_body, "conch_value",
+                           json_object_new_int64(new_conch_value));
+    json_object_object_add(conch_release, "body", conch_release_body);
+
+    // Send release message to Leader
+    msg_send(conch_release);
+}
+
 int main(void)
 {
-    char* input_line = NULL;
-    size_t input_len = 0;
-    ssize_t input_bytes_read;
-
-    if ((input_bytes_read = getline(&input_line, &input_len, stdin)) != -1)
+    json_object* init_msg = msg_recv();
+    if (init_msg == NULL)
     {
-        json_object* init_msg = json_tokener_parse(input_line);
-        json_object* init_msg_reply = init_reply(init_msg);
-        printf("%s\n", json_object_to_json_string(init_msg_reply));
-        fflush(stdout);
-        json_object_put(init_msg_reply);
-        json_object_put(init_msg);
+        fprintf(stderr, "expected init message, got EOF");
+        exit(EXIT_FAILURE);
     }
-
-    // NOTE: This is purely for testing; will be removed in final version
-    Queue* queue = queue_init(10);
-    for (int i = 0; i < 10; i++)
-    {
-        int* data = malloc(sizeof(int));
-        *data = i;
-        queue_enqueue(queue, data);
-    }
-    for (int i = 0; i < 10; i++)
-    {
-        int* data = queue_dequeue(queue);
-        printf("%d\n", *data);
-        free(data);
-    }
-    queue_free(queue);
-
-    free(input_line);
+    msg_send(init_reply(init_msg));
+    json_object_put(init_msg);
 }
 
 json_object* init_reply(json_object* init_msg)

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -1,29 +1,89 @@
-#include <json-c/json.h>
-#include <stdio.h>
-
 #include "../../lib/collections.h"
 #include "../../lib/util.h"
 #include "json-c/json_object.h"
+#include <json-c/json.h>
+#include <stdio.h>
+
+char* LEADER_NODE = "n0";
 
 json_object* init_reply(json_object* init_msg);
 
 void client_request_handler(json_object* client_request);
 void conch_response_handler(json_object* conch_response);
+void conch_request_handler(json_object* conch_request, Queue* conch_queue);
+void conch_release_handler(json_object* conch_release, Conch* conch);
+void conch_response_dispatcher(Conch* conch, Queue* request_queue);
 
-char* LEADER_NODE = "n0";
+int main(void)
+{
+    json_object* init_msg = msg_recv();
+    if (init_msg == NULL)
+    {
+        fprintf(stderr, "expected init message, got EOF");
+        exit(EXIT_FAILURE);
+    }
+    msg_send(init_reply(init_msg));
+    json_object_put(init_msg);
+
+    // TODO: Event loops
+}
+
+json_object* init_reply(json_object* init_msg)
+{
+    return generic_reply(init_msg);
+}
+
+// Used exclusively by Leader
+void conch_request_handler(json_object* conch_request, Queue* request_queue)
+{
+    json_object* body = json_object_object_get(conch_request, "body");
+    queue_enqueue(request_queue,
+                  json_object_object_get(body, "original_client_request"));
+}
+
+// Used exclusively by Leader
+void conch_response_dispatcher(Conch* conch, Queue* request_queue)
+{
+    json_object* conch_response = json_object_new_object();
+    json_object* original_client_request = queue_dequeue(request_queue);
+
+    // Construct conch response message
+    json_object* src = json_object_new_string(LEADER_NODE);
+    json_object_object_add(conch_response, "src", src);
+
+    json_object* dest = json_object_object_get(original_client_request, "dest");
+    json_object_get(dest);
+    json_object_object_add(conch_response, "dest", dest);
+
+    json_object* body = json_object_new_object();
+    json_object_object_add(body, "type",
+                           json_object_new_string("conch_response"));
+    int64_t conch_value = conch_checkout(conch);
+    json_object_object_add(body, "conch_value",
+                           json_object_new_int64(conch_value));
+    json_object_get(original_client_request);
+    json_object_object_add(body, "original_client_request",
+                           original_client_request);
+    json_object_object_add(conch_response, "body", body);
+
+    // Send conch response message (to Follower)
+    msg_send(conch_response);
+}
+
+// Used exclusively by Leader
+void conch_release_handler(json_object* conch_release, Conch* conch)
+{
+    json_object* body = json_object_object_get(conch_release, "body");
+    int64_t new_conch_value =
+        json_object_get_int64(json_object_object_get(body, "conch_value"));
+    conch_checkin(conch, new_conch_value);
+}
 
 void client_request_handler(json_object* client_request)
 {
-
-    /* Conch request schema
-    {
-      "src": "n_",
-      "dest": "n0",
-      "body": { "type": "conch_request", "client_id": "c_" }
-    }
-    */
     json_object* conch_request = json_object_new_object();
 
+    // Construct conch request message
     json_object* dest = json_object_new_string(LEADER_NODE);
     json_object_object_add(conch_request, "dest", dest);
 
@@ -38,45 +98,31 @@ void client_request_handler(json_object* client_request)
     json_object_object_add(body, "original_client_request", client_request);
     json_object_object_add(conch_request, "body", body);
 
+    // Send conch request message (to Leader)
     msg_send(conch_request);
 }
 
 void conch_response_handler(json_object* conch_response)
 {
-    /* Conch response schema
-    {
-      "src": "n0",
-      "dest": "n_",
-      "body": { "msg_id": _, "type": "conch_response", "conch_value": _,
-    "original_client_request": _ }
-    }
-    */
-
+    // Construct client response message
     json_object* conch_response_body =
         json_object_object_get(conch_response, "body");
     json_object* client_response = generic_reply(
         json_object_object_get(conch_response_body, "original_client_request"));
 
-    // id set to current conch_value
     json_object* conch_value =
         json_object_object_get(conch_response_body, "conch_value");
     json_object_get(conch_value);
     json_object_object_add(json_object_object_get(client_response, "body"),
                            "conch value", conch_value);
 
-    // Send response message to client
+    // Send client response message (to client)
     msg_send(client_response);
 
     // Increment conch_value
     int64_t new_conch_value = json_object_get_int64(conch_value) + 1;
 
-    /* Conch release schema
-    {
-      "src": "n_",
-      "dest": "n0",
-      "body": { "type": "conch_release", "conch_value": _ }
-    }
-    */
+    // Construct conch release message
     json_object* conch_release = json_object_new_object();
 
     json_object* dest = json_object_new_string(LEADER_NODE);
@@ -93,23 +139,6 @@ void conch_response_handler(json_object* conch_response)
                            json_object_new_int64(new_conch_value));
     json_object_object_add(conch_release, "body", conch_release_body);
 
-    // Send release message to Leader
+    // Send conch release message (to Leader)
     msg_send(conch_release);
-}
-
-int main(void)
-{
-    json_object* init_msg = msg_recv();
-    if (init_msg == NULL)
-    {
-        fprintf(stderr, "expected init message, got EOF");
-        exit(EXIT_FAILURE);
-    }
-    msg_send(init_reply(init_msg));
-    json_object_put(init_msg);
-}
-
-json_object* init_reply(json_object* init_msg)
-{
-    return generic_reply(init_msg);
 }


### PR DESCRIPTION
# Overview

This PR introduces a proposed API to enable the [_Lord of the Flies_-inspired](https://william-golding.co.uk/resources/the-conch) "conch" mechanics that enable: 

1. *Follower* nodes to request future promises of obtaining the conch from the *Leader* node upon receiving a client request
2. The *Leader* to prioritize conch requests in a `Queue` and dispatch conch responses when the conch is available
3. *Follower* nodes to handle conch responses, respond to the original client request appropriately, and release the conch back to the *Leader*

The addition of the `Conch` data structure in `collections.{c,h}` and a handful of functions in `challenge-2.c` comprise the interface (along with a `Queue` (introduced in #1) managed by the *Leader*).

## Additional Detail

See the updated [note](https://github.com/khollbach/gossip-glomers-c/blob/e5ce33b89b9fe9e0c403a311faae54b853e5cf11/notes/2023-07-25.md) for more detail about intended flow of messages.

In terms of naming conventions, a *handler* receives a `json_object*` and can additionally dispatch a message (or messages) and/or mutates something. A *dispatcher* doesn't receive a `json_object*` but can dispatch a message (or messages) and/or mutates something.

### Tests

(This code has not been tested yet, but everything compiles as of writing.)

## Feedback Desired

- Checking for message flow correctness (i.e., correct input & output messages)
- An extra set of eyes to make sure I didn't forget to call `json_object_get` to increment the ref count of a `json_object` anywhere
- API suggestions (e.g., safety checks on the `Conch` and `Queue` such as calling `conch_is_available` or `queue_is_full` are the responsibility of the caller and are NOT in function bodies herein)

## Breaking Changes

N/A