### PR TITLE
[NOREF] Implement polymorphic dynamic array

### DIFF
--- a/lib/collections.c
+++ b/lib/collections.c
@@ -179,7 +179,7 @@ void list_set_at(List* list, size_t index, void* item)
     list->data[index] = item;
 }
 
-void list_resize(List* list)
+static void list_resize(List* list)
 {
     if (list->length * 2 >= list->max_length)
     {

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -191,7 +191,8 @@ static void list_resize(List* list)
             exit(EXIT_FAILURE);
         }
     }
-    else if (list->length * 4 <= list->max_length)
+    else if (list->length * 4 <= list->max_length &&
+             list->max_length > INITIAL_LIST_MAX_LENGTH)
     {
         list->max_length /= 2;
         list->data = realloc(list->data, list->max_length * sizeof(void*));
@@ -205,8 +206,9 @@ static void list_resize(List* list)
 
 void list_append(List* list, void* item)
 {
-    list->data[list->length++] = item;
+    list->length += 1;
     list_resize(list);
+    list->data[list->length - 1] = item;
 }
 
 void* list_pop(List* list)
@@ -216,18 +218,15 @@ void* list_pop(List* list)
         fprintf(stderr, "Error: list_pop: list is empty\n");
         exit(EXIT_FAILURE);
     }
-    return list->data[--list->length];
+    void* returned_item = list->data[--list->length];
     list_resize(list);
+    return returned_item;
 }
 
 size_t list_length(List* list) { return list->length; }
 
 void list_free(List* list)
 {
-    for (size_t i = 0; i < list->length; i++)
-    {
-        free(list->data[i]);
-    }
     free(list->data);
     free(list);
 }

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -86,7 +86,8 @@ void queue_free(Queue* queue)
 {
     while (!queue_is_empty(queue))
     {
-        queue_dequeue(queue);
+        void* data = queue_dequeue(queue);
+        free(data);
     }
     free(queue);
 }

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -181,7 +181,7 @@ void list_set_at(List* list, size_t index, void* item)
 
 static void list_resize(List* list)
 {
-    if (list->length * 2 >= list->max_length)
+    if (list->length == list->max_length)
     {
         list->max_length *= 2;
         list->data = realloc(list->data, list->max_length * sizeof(void*));

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -3,6 +3,8 @@
 
 #include "collections.h"
 
+#define INITIAL_LIST_MAX_LENGTH 16
+
 typedef struct Node
 {
     void* data;
@@ -129,3 +131,103 @@ int64_t conch_checkout(Conch* conch)
 bool conch_is_available(Conch* conch) { return conch->conch_available; }
 
 void conch_free(Conch* conch) { free(conch); }
+
+// Dynamic Array ADT
+typedef struct List
+{
+    size_t length;
+    size_t max_length;
+    void** data;
+} List;
+
+List* list_init(void)
+{
+    List* list = malloc(sizeof(List));
+    if (list == NULL)
+    {
+        fprintf(stderr, "Error: list_init: malloc failed\n");
+        exit(EXIT_FAILURE);
+    }
+    list->length = 0;
+    list->max_length = INITIAL_LIST_MAX_LENGTH;
+    list->data = malloc(INITIAL_LIST_MAX_LENGTH * sizeof(void*));
+    if (list->data == NULL)
+    {
+        fprintf(stderr, "Error: list_init: malloc failed\n");
+        exit(EXIT_FAILURE);
+    }
+    return list;
+}
+
+void* list_get_at(List* list, size_t index)
+{
+    if (index >= list->length)
+    {
+        fprintf(stderr, "Error: list_get_at: index out of bounds\n");
+        exit(EXIT_FAILURE);
+    }
+    return list->data[index];
+}
+
+void list_set_at(List* list, size_t index, void* item)
+{
+    if (index >= list->length)
+    {
+        fprintf(stderr, "Error: list_set_at: index out of bounds\n");
+        exit(EXIT_FAILURE);
+    }
+    list->data[index] = item;
+}
+
+void list_resize(List* list)
+{
+    if (list->length * 2 >= list->max_length)
+    {
+        list->max_length *= 2;
+        list->data = realloc(list->data, list->max_length * sizeof(void*));
+        if (list->data == NULL)
+        {
+            fprintf(stderr, "Error: list_resize: realloc failed\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+    else if (list->length * 4 <= list->max_length)
+    {
+        list->max_length /= 2;
+        list->data = realloc(list->data, list->max_length * sizeof(void*));
+        if (list->data == NULL)
+        {
+            fprintf(stderr, "Error: list_resize: realloc failed\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+void list_append(List* list, void* item)
+{
+    list->data[list->length++] = item;
+    list_resize(list);
+}
+
+void* list_pop(List* list)
+{
+    if (list->length == 0)
+    {
+        fprintf(stderr, "Error: list_pop: list is empty\n");
+        exit(EXIT_FAILURE);
+    }
+    return list->data[--list->length];
+    list_resize(list);
+}
+
+size_t list_length(List* list) { return list->length; }
+
+void list_free(List* list)
+{
+    for (size_t i = 0; i < list->length; i++)
+    {
+        free(list->data[i]);
+    }
+    free(list->data);
+    free(list);
+}

--- a/lib/collections.h
+++ b/lib/collections.h
@@ -6,6 +6,7 @@
 
 typedef struct Queue Queue;
 typedef struct Conch Conch;
+typedef struct List List;
 
 Queue* queue_init(size_t size);
 void queue_enqueue(Queue* queue, void* data);
@@ -19,3 +20,11 @@ void conch_checkin(Conch* conch, int64_t new_conch_value);
 int64_t conch_checkout(Conch* conch);
 bool conch_is_available(Conch* conch);
 void conch_free(Conch* conch);
+
+List* list_init(void);
+void list_append(List* list, void* data);
+void* list_pop(List* list);
+void* list_get_at(List* list, size_t index);
+void list_set_at(List* list, size_t index, void* data);
+size_t list_length(List* list);
+void list_free(List* list);


### PR DESCRIPTION
# Overview

This PR introduces the dynamic array (`List`) data structure to our `collections` library.

## Additional Detail

This implementation doesn't *completely* implement a dynamic array for a Set or Sequence ADT (i.e., there are some operations missing, such as `insert_at(i,x)` or `delete_at(i)`), but it provides enough of the interface to make it useful. In particular, the internal `list_resize` provides the dynamic resizing to enable $O(1)_a$ `append(x)` and `pop()` operations.

### Tests

None 😬

## Feedback Desired

- I prepended `list_` to the names of the functions comprising this interface, but this is mostly to mimic the naming conventions from Python and to avoid using `array` anywhere, which might be conflated with a static array.
  - I'm also open to different names!
- Double checking I did the pre-/post-incrementing correctly!
- Sharing thoughts on what the extent of the `free`-ing responsibilities of the `list_free` function
  - There are multiple levels of indirection here; the current implementation frees the pointers of items in the underlying static array, the `data` field pointer to the underlying array, and finally, the `List` struct itself.
  - I'm never quite sure how much responsibility the caller takes on; for example, what if the pointers in the underlying static array point to other `malloc`-ed memory? Should we be super flexible and take as a parameter a function that deals with this, third layer of memory management?
  - FWIW, our `queue_free` never actually `free`s the `data` pointer any time `queue_free` is called whilst there are still items in the queue! I was thinking this is a bug/oversight, but then again, the caller/user is the one providing the `void* data` pointer in the enqueue step (i.e., the queue implementation never allocates memory for contained data).

## Breaking Changes

N/A